### PR TITLE
Avoid the MergeBam step

### DIFF
--- a/bin/bwa_multifastq
+++ b/bin/bwa_multifastq
@@ -169,6 +169,8 @@ def main():
 	arg('-M', dest='mark_secondary', help='mark shorter split hits as secondary', action='store_true')
 	arg('-B', dest='mismatch_penalty', type=int, default=None,
 		help='penalty for a mismatch')
+	arg('-j', dest='not_alt_aware', action='store_true', default=False,
+		help='treat ALT contigs as part of the primary assembly (i.e. ignore <idxbase>.alt file)')
 
 	arg('fastq', metavar='FASTQ', nargs='+', help='FASTQ input files, in pairs of two')
 	args = parser.parse_args()
@@ -190,6 +192,8 @@ def main():
 		bwa_cmd += ['-M']
 	if args.mismatch_penalty:
 		bwa_cmd += ['-B', str(args.mismatch_penalty)]
+	if args.not_alt_aware:
+		bwa_cmd += ['-j']
 
 	# Check the FASTQ files before mapping anything so we can fail early
 	# in case of problems.

--- a/bin/bwa_multifastq
+++ b/bin/bwa_multifastq
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# kate: space-indent off; indent-width 4; tab-width 4;
+"""
+A wrapper for BWA-MEM that can process multiple FASTQ pairs coming from a
+single library, allowing to stream the output into samblaster.
+
+The idea is to use it thus:
+
+    bwa_multifastq ... Lane01.1.fastq Lane01.2.fastq Lane02.1.fastq Lane02.2.fastq (etc.) |
+    samblaster | samtools sort - ...
+
+Except for the external files that samtools sort writes, all I/O is streamed,
+which means that it is possible to go from FASTQ to a sorted and
+duplicate-marked BAM in a single step.
+"""
+import subprocess
+from argparse import ArgumentParser
+import os
+import re
+from collections import namedtuple
+import sys
+from itertools import tee
+import gzip
+
+__author__ = "Marcel Martin"
+
+
+FastqInfo = namedtuple('FastqInfo', ['instrument', 'run', 'flowcell', 'lane', 'barcode'])
+
+
+def fastq_header(path):
+	"""
+	Inspect a FASTQ file and return a FastqInfo object. If a particular piece of
+	information is unknown, the corresponding attribute of FastqInfo is set to
+	None.
+
+	This will try to auto-detect different types of Illumina headers:
+	@HWI-ST552_0:4:1101:1179:1939#0/1
+	@HWI_ST139:8:1:1202:1874#GATCAG/1
+	@HWI-ST344:204:D14G8ACXX:8:1101:1638:2116 1:N:0:CGATGT
+	@MISEQ:56:000000000-A4YM7:1:1101:15071:2257 1:N:0:CTTGTA
+	@FCD20MKACXX:8:1101:1215:2155#TCGTAAGC/1
+
+	The format of a FASTQ header starting with CASAVA 1.8 is:
+
+	<instrument-name>:<run ID>:<flowcell ID>:<lane-number>:<tile-number>:<x-pos>:<y-pos>
+	<read number>:<is filtered>:<control number>:<barcode sequence>
+	"""
+	try:
+		line = path.readline()
+	except:
+		if path.endswith('.gz'):
+			openfunc = gzip.open
+		else:
+			openfunc = open
+		with openfunc(path, 'rt') as f:
+			line = f.readline()
+	line = line.rstrip()
+	assert line.startswith('@')
+	line = line[1:]
+	# ignore comment field for now
+	header = line.split(' ', maxsplit=1)
+	read_name = header[0]
+	comment = header[1] if len(header) == 2 else None
+	fields = read_name.split(':')
+	if len(fields) == 7:
+		# probably new CASAVA 1.8 format
+		instrument = fields[0]
+		run_id = int(fields[1])
+		flowcell = fields[2]
+		lane = int(fields[3])
+		barcode = None
+		if comment:
+			comment_fields = comment.split(':')
+			if len(comment_fields) == 4:
+				barcode = comment_fields[3]
+	elif len(fields) == 5:
+		if '#' in fields[4]:
+			f = fields[4].split('#', maxsplit=1)[1]
+			barcode = f.split('/', maxsplit=1)[0]
+		else:
+			barcode = None
+		run_id = None
+		lane = int(fields[1])
+		if 'XX' in fields[0]:
+			instrument, flowcell = None, fields[0]
+		else:
+			instrument, flowcell = fields[0], None
+	else:
+		raise ValueError("FASTQ header format not recognized")
+	if barcode and not re.match('[acgtnACGTN]+$', barcode):
+		barcode = None
+
+	return FastqInfo(instrument=instrument, run=run_id, flowcell=flowcell, lane=lane, barcode=barcode)
+
+
+def available_cpu_count():
+	"""
+	Number of available virtual or physical CPUs on this system.
+
+	Adapted from http://stackoverflow.com/a/1006301/715090
+	"""
+	# cpuset may restrict the number of available processors
+	cpus = 1
+	try:
+		m = re.search(r'(?m)^Cpus_allowed:\s*(.*)$', open('/proc/self/status').read())
+		if m:
+			res = bin(int(m.group(1).replace(',', ''), 16)).count('1')
+			if res > 0:
+				cpus = res
+	except IOError:
+		pass
+
+	try:
+		import multiprocessing
+		cpus = min(cpus, multiprocessing.cpu_count())
+	except (ImportError, NotImplementedError):
+		pass
+	return cpus
+
+
+def pairs(iterable):
+	"""
+	s = [0, 1, 2, 3, 4, 5]
+	>>> list(pairs(s))
+	[[0, 1], [2, 3], [4, 5]]
+	"""
+	it = iter(iterable)
+	for a in it:
+		yield a, next(it)
+
+
+def fake_pg_headers(existing, bwa_calls):
+	"""
+	Create fake @PG headers for the given bwa_calls using the existing
+	header as a template.
+	"""
+	# Extract version from existing record
+	for field in existing.split('\t')[1:]:
+		if field.startswith('VN'):
+			version = field
+	for i, bwa_call in enumerate(bwa_calls):
+		pgid = 'ID:bwa' if i == 0 else 'ID:bwa-{:04d}'.format(i)
+		cmd = ' '.join(bwa_call.command)
+		pg = '\t'.join(['@PG', pgid, 'PN:bwa', version, 'CL:' + cmd])
+		yield pg
+
+
+class BwaCall:
+	def __init__(self, command, rg_header):
+		self.command = command
+		self.rg_header = rg_header
+
+
+def main():
+	parser = ArgumentParser(description=__doc__)
+	arg = parser.add_argument
+	arg('-r', '--reference', metavar="REF", required=True,
+		help="Reference FASTA file to use. A bwa index must"
+			" exist.")
+	arg('--sample', help='Read group sample (SM)', required=True)
+	arg('--library', help='Read group library (LB)')
+	arg('--platform', help='read group platform (PL)', default='illumina')
+
+	group = parser.add_argument_group('Options passed through to "bwa mem"')
+	arg = group.add_argument
+	arg('--threads', '-t', metavar='N', type=int, default=available_cpu_count(),
+		help="Use at most N threads (default on this machine: %(default)s)")
+	arg('-M', dest='mark_secondary', help='mark shorter split hits as secondary', action='store_true')
+	arg('-B', dest='mismatch_penalty', type=int, default=None,
+		help='penalty for a mismatch')
+
+	arg('fastq', metavar='FASTQ', nargs='+', help='FASTQ input files, in pairs of two')
+	args = parser.parse_args()
+
+	if not os.path.exists(args.reference):
+		parser.error('reference file "{}" does not exist'.format(args.reference))
+
+	for ext in ('amb', 'ann', 'bwt', 'pac', 'sa'):
+		path1 = args.reference + '.' + ext
+		path2 = args.reference + '.64.' + ext
+		if not os.path.exists(path1) and not os.path.exists(path2):
+			print("File {}.{} does not exist -- it seems there's no index"
+				"usable by BWA at the given reference location.".format(
+					args.reference, ext), file=sys.stderr)
+			sys.exit(2)
+
+	bwa_cmd = ['bwa', 'mem', '-t', str(args.threads)]
+	if args.mark_secondary:
+		bwa_cmd += ['-M']
+	if args.mismatch_penalty:
+		bwa_cmd += ['-B', str(args.mismatch_penalty)]
+
+	# Check the FASTQ files before mapping anything so we can fail early
+	# in case of problems.
+	read_group_ids = set()
+	bwa_calls = []
+	if len(args.fastq) % 2 != 0:
+		parser.error("An even number of FASTQ files is expected (only paired-end data is supported)")
+	for fastq1, fastq2 in pairs(args.fastq):
+		header1 = fastq_header(fastq1)
+		header2 = fastq_header(fastq2)
+		if header1 != header2:
+			sys.exit('FASTQ {!r} does not seem to be partner of {!r}'.format(fastq1, fastq2))
+		flowcell = header1.flowcell
+		if flowcell is None:
+			flowcell = header1.instrument
+		if flowcell is None:
+			flowcell = 'FLOWCELLID'
+		lane = header1.lane
+		if lane is None:
+			lane = 'LANE'
+		read_group_id = '{}.{}.{}'.format(flowcell, args.sample, lane)
+		rg = read_group_id
+		i = 0
+		while rg in read_group_ids:
+			rg = '{}-{}'.format(read_group_id, i+1)
+			i += 1
+		read_group_ids.add(rg)
+		read_group_id = rg
+		platform_unit = read_group_id
+		rg_header = '@RG\tID:{id}\tPU:{pu}\tSM:{sample}'.format(
+			id=read_group_id,
+			pu=platform_unit,
+			sample=args.sample)
+		if args.library:
+			rg_header += '\tLB:{}'.format(args.library)
+		if args.platform:
+			rg_header += '\tPL:{}'.format(args.platform)
+
+		# Do not leave the literal tabs in the command-line. BWA is kind enough
+		# to recognize the \t escape sequence for us. This avoids having a
+		# malformed SAM header due to the embedded tab characters.
+		rg_param = rg_header.replace('\t', '\\t')
+		cmd = bwa_cmd + ['-R', rg_param, args.reference, fastq1, fastq2]
+
+		bwa_calls.append(BwaCall(command=cmd, rg_header=rg_header))
+
+	# Actually run BWA-MEM on all the FASTQ pairs
+	is_first_pair = True
+	write = sys.stdout.buffer.write  # avoid some dictionary lookups
+	for bwa_call in bwa_calls:
+		print('Running', bwa_call.command, file=sys.stderr)
+		with subprocess.Popen(bwa_call.command, stdout=subprocess.PIPE) as bwa:
+			for line in bwa.stdout:
+				if line.startswith(b'@'):
+					if is_first_pair:
+						if line.startswith(b'@RG'):
+							assert line == bwa_calls[0].rg_header.encode('ascii') + b'\n'
+							# write our own RG lines
+							for bc in bwa_calls:
+								write(bc.rg_header.encode('ascii') + b'\n')
+						elif line.startswith(b'@PG'):
+							for pg in fake_pg_headers(line.decode('ascii'), bwa_calls):
+								write(pg.encode('ascii') + b'\n')
+						else:
+							write(line)
+				else:
+					write(line)
+		if bwa.returncode != 0:
+			sys.exit('BWA exited with error code {}'.format(bwa.returncode))
+		is_first_pair = False
+
+
+if __name__ == '__main__':
+	main()

--- a/configuration/uppmax-localhost.config
+++ b/configuration/uppmax-localhost.config
@@ -69,10 +69,6 @@ process {
   $MarkDuplicates {
     memory = {returnMin(params.singleCPUMem * 2 * task.attempt, params.totalMemory)}
   }
-  $MergeBams {
-    cpus = 16
-    memory = {params.totalMemory}
-  }
   $RealignerTargetCreator {
     cpus = 4
     memory = {returnMin(params.singleCPUMem * 4 * task.attempt, params.totalMemory)}

--- a/configuration/uppmax-slurm.config
+++ b/configuration/uppmax-slurm.config
@@ -57,11 +57,6 @@ process {
     queue = 'core'
     time = {params.runTime * task.attempt}
   }
-  $MergeBams {
-    memory = {params.singleCPUMem * task.attempt}
-    queue = 'core'
-    time = {params.runTime * task.attempt}
-  }
   $RealignerTargetCreator {
     time = {params.runTime * task.attempt}
   }

--- a/main.nf
+++ b/main.nf
@@ -200,7 +200,7 @@ process MapReads {
   // TODO idRun is unused. It was previously used as the RG id, but that
   // is now deduced automatically by the bwa_multifastq script.
   input:
-    set idPatient, status, idSample, idRun, file(fastqFiles1), file(fastqFiles2) from groupedFastq
+    set idPatient, status, idSample, idRun, file(fastqFiles1: '???_R1_001.fastq.gz'), file(fastqFiles2: '???_R2_001.fastq.gz') from groupedFastq
     set file(genomeFile), file(bwaIndex) from Channel.value([referenceMap.genomeFile, referenceMap.bwaIndex])
 
   output:

--- a/main.nf
+++ b/main.nf
@@ -29,8 +29,7 @@ kate: syntax groovy; space-indent on; indent-width 2;
 --------------------------------------------------------------------------------
  Processes overview
  - RunFastQC - Run FastQC for QC on fastq files
- - MapReads - Map reads with BWA
- - MergeBams - Merge BAMs if multilane samples
+ - MapReads - Map reads with BWA (handles also multi-lane samples)
  - MarkDuplicates - Mark Duplicates with Picard
  - RealignerTargetCreator - Create realignment target intervals
  - IndelRealigner - Realign BAMs as T/N pair
@@ -192,80 +191,37 @@ if (verbose) fastQCreport = fastQCreport.view {
   Files : [${it[0].fileName}, ${it[1].fileName}]"
 }
 
-process MapReads {
-  tag {idPatient + "-" + idRun}
+// group by sample
+groupedFastq = fastqFiles.groupTuple(by:[0, 1, 2])
 
+process MapReads {
+  tag {idPatient + "-" + idSample}
+
+  // TODO idRun is unused. It was previously used as the RG id, but that
+  // is now deduced automatically by the bwa_multifastq script.
   input:
-    set idPatient, status, idSample, idRun, file(fastqFile1), file(fastqFile2) from fastqFiles
+    set idPatient, status, idSample, idRun, file(fastqFiles1), file(fastqFiles2) from groupedFastq
     set file(genomeFile), file(bwaIndex) from Channel.value([referenceMap.genomeFile, referenceMap.bwaIndex])
 
   output:
-    set idPatient, status, idSample, idRun, file("${idRun}.bam") into mappedBam
+    set idPatient, status, idSample, file("${idSample}_${status}.bam") into mappedBam
 
   when: step == 'mapping'
 
   script:
-  readGroup = "@RG\\tID:$idRun\\tPU:$idRun\\tSM:$idSample\\tLB:$idSample\\tPL:illumina"
   // adjust mismatch penalty for tumor samples
   extra = status == 1 ? "-B 3 " : ""
+  fastq = [fastqFiles1.collect{"$it"}, fastqFiles2.collect{"$it"}].transpose().flatten().join(' ')
+  samtools_threads = task.cpus > 8 ? 8 : task.cpus
+
   """
-  bwa mem -R \"$readGroup\" ${extra}-t $task.cpus -M \
-  $genomeFile $fastqFile1 $fastqFile2 | \
-  samtools sort --threads $task.cpus -m 4G - > ${idRun}.bam
+  bwa_multifastq -M --sample $idSample ${extra}-t $task.cpus -r $genomeFile $fastq | \
+    samtools sort --threads $samtools_threads -m 2G - > ${idSample}_${status}.bam
   """
 }
 
 if (verbose) mappedBam = mappedBam.view {
-  "Mapped BAM (single or to be merged):\n\
-  ID    : ${it[0]}\tStatus: ${it[1]}\tSample: ${it[2]}\tRun   : ${it[3]}\n\
-  File  : [${it[4].fileName}]"
-}
-
-// Sort bam whether they are standalone or should be merged
-// Borrowed code from https://github.com/guigolab/chip-nf
-
-singleBam = Channel.create()
-groupedBam = Channel.create()
-mappedBam.groupTuple(by:[0,1,2])
-  .choice(singleBam, groupedBam) {it[3].size() > 1 ? 1 : 0}
-singleBam = singleBam.map {
-  idPatient, status, idSample, idRun, bam ->
-  [idPatient, status, idSample, bam]
-}
-
-process MergeBams {
-  tag {idPatient + "-" + idSample}
-
-  input:
-    set idPatient, status, idSample, idRun, file(bam) from groupedBam
-
-  output:
-    set idPatient, status, idSample, file("${idSample}.bam") into mergedBam
-
-  when: step == 'mapping'
-
-  script:
-  """
-  samtools merge --threads $task.cpus ${idSample}.bam $bam
-  """
-}
-
-if (verbose) singleBam = singleBam.view {
-  "Single BAM:\n\
-  ID    : ${it[0]}\tStatus: ${it[1]}\tSample: ${it[2]}\n\
-  File  : [${it[3].fileName}]"
-}
-
-if (verbose) mergedBam = mergedBam.view {
-  "Merged BAM:\n\
-  ID    : ${it[0]}\tStatus: ${it[1]}\tSample: ${it[2]}\n\
-  File  : [${it[3].fileName}]"
-}
-
-mergedBam = mergedBam.mix(singleBam)
-
-if (verbose) mergedBam = mergedBam.view {
-  "BAM for MarkDuplicates:\n\
+  "Mapped BAM:\n\
   ID    : ${it[0]}\tStatus: ${it[1]}\tSample: ${it[2]}\n\
   File  : [${it[3].fileName}]"
 }
@@ -276,7 +232,7 @@ process MarkDuplicates {
   publishDir '.', saveAs: { it == "${bam}.metrics" ? "$directoryMap.markDuplicatesQC/$it" : "$directoryMap.nonRealigned/$it" }, mode: 'copy'
 
   input:
-    set idPatient, status, idSample, file(bam) from mergedBam
+    set idPatient, status, idSample, file(bam) from mappedBam
 
   output:
     set idPatient, file("${idSample}_${status}.md.bam"), file("${idSample}_${status}.md.bai") into duplicates


### PR DESCRIPTION
This PR introduces a wrapper script `bwa_multifastq` for bwa mem that makes it possible to map multiple FASTQ pairs at the same time, thus eliminating the need for the MergeBam process.

The advantage of the wrapper is that it does not create temporary files. Instead, it streams everything, avoiding I/O and a compression/decompression step: The FASTQs are streamed into multiple BWA processes and the output of those is merged on-the-fly into a single SAM output stream. This can then be sent directly into samtools sort to produce the final output file.

The wrapper also automatically deduces a read group id from the flowcell id
stored in the input FASTQ files.

The logic for deciding whether or not to merge BAM files was also removed since it is no longer needed.

The changes in this commit were also introduced by PR #242, but that PR went
further by replacing MarkDuplicates with samblaster. This commit keeps
MarkDuplicates.