### PR TITLE
Bam files for manta no longer saved (but still channeled to strelka)

### DIFF
--- a/somaticVC.nf
+++ b/somaticVC.nf
@@ -532,8 +532,11 @@ if (params.verbose) strelkaOutput = strelkaOutput.view {
 process RunManta {
   tag {idSampleTumor + "_vs_" + idSampleNormal}
 
-  publishDir directoryMap.manta, mode: 'link'
-
+  publishDir directoryMap.manta, mode: 'link',
+      saveAs: {filename ->
+                  if (filename.endsWith(".bam") || filename.endsWith(".bai")) null
+                  else $filename
+                  }
   input:
     set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor) from bamsForManta
     set file(genomeFile), file(genomeIndex) from Channel.value([


### PR DESCRIPTION
RunManta changed so that bam and bai files are no longer added to publishDir (results/Manta)
