### PR TITLE
2 threads and 2 cpus for each FastQC process

### DIFF
--- a/configuration/uppmax-localhost.config
+++ b/configuration/uppmax-localhost.config
@@ -101,6 +101,7 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   withName:RunFastQC {
+    cpus = 2 // FastQC is only capable of running one thread per fastq file.
     errorStrategy = {task.exitStatus == 143 ? 'retry' : 'ignore'}
   }
   withName:RunFreeBayes {

--- a/configuration/uppmax-slurm.config
+++ b/configuration/uppmax-slurm.config
@@ -91,6 +91,7 @@ process {
     queue = 'core'
   }
   withName:RunFastQC {
+    cpus = 2 // FastQC is only capable of running one thread per fastq file.
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   withName:RunFreeBayes {

--- a/main.nf
+++ b/main.nf
@@ -150,7 +150,7 @@ process RunFastQC {
 
   script:
   """
-  fastqc -q ${fastqFile1} ${fastqFile2}
+  fastqc -t 2 -q ${fastqFile1} ${fastqFile2}
   """
 }
 


### PR DESCRIPTION
This PR improves the execution of FastQC so that it uses one thread per fastq file as described in #631.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] Test suite passes (`./scripts/test.sh -p docker -t ALL`).

Tests do not pass. But I highly suspect that is due to my personal setup for some reason. Travis checks should give a final decision.
