### PR TITLE
input bam file has always the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   [#663](https://github.com/SciLifeLab/Sarek/pull/663) - Update `do_release.sh` script
 
+### `Fixed`
+
+-   [#665](https://github.com/SciLifeLab/Sarek/pull/665) - Input bam file now has always the same name (whether it is from a single fastq pair or multiple) in the MarkDuplicates process, so metrics too
+
 ## [2.2.1] - 2018-10-04
 
 ### `Changed`

--- a/main.nf
+++ b/main.nf
@@ -233,12 +233,12 @@ process MarkDuplicates {
     }
 
   input:
-    set idPatient, status, idSample, file(bam) from mergedBam
+    set idPatient, status, idSample, file("${idSample}.bam") from mergedBam
 
   output:
     set idPatient, file("${idSample}_${status}.md.bam"), file("${idSample}_${status}.md.bai") into duplicateMarkedBams
     set idPatient, status, idSample, val("${idSample}_${status}.md.bam"), val("${idSample}_${status}.md.bai") into markDuplicatesTSV
-    file ("${bam}.metrics") into markDuplicatesReport
+    file ("${idSample}.bam.metrics") into markDuplicatesReport
 
   when: step == 'mapping' && !params.onlyQC
 
@@ -247,8 +247,8 @@ process MarkDuplicates {
   gatk --java-options -Xmx${task.memory.toGiga()}g \
   MarkDuplicates \
   --MAX_RECORDS_IN_RAM 50000 \
-  --INPUT ${bam} \
-  --METRICS_FILE ${bam}.metrics \
+  --INPUT ${idSample}.bam \
+  --METRICS_FILE ${idSample}.bam.metrics \
   --TMP_DIR . \
   --ASSUME_SORT_ORDER coordinate \
   --CREATE_INDEX true \


### PR DESCRIPTION
- input bam file has always the same name in the MarkDuplicates process
before, it was called `runId.bam` for single pair fastq and `sampleId.bam` for multiple pairs fastq

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [x] `CHANGELOG.md` is updated