### PR TITLE
fix expected output of PullSingularityContainers process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Fixed`
 
 -   [#665](https://github.com/SciLifeLab/Sarek/pull/665) - Input bam file now has always the same name (whether it is from a single fastq pair or multiple) in the MarkDuplicates process, so metrics too
+-   [#672](https://github.com/SciLifeLab/Sarek/pull/672) - process `PullSingularityContainers` from `buildContainers.nf` now expect a file with the correct `.simg` extension for singularity images, and no longer the `.img` one.
 
 ## [2.2.1] - 2018-10-04
 

--- a/buildContainers.nf
+++ b/buildContainers.nf
@@ -92,7 +92,7 @@ process PullSingularityContainers {
     val container from singularityContainers
 
   output:
-    file("${container}-${params.tag}.img") into imagePulled
+    file("${container}-${params.tag}.simg") into imagePulled
 
   when: params.singularity
 


### PR DESCRIPTION
- process `PullSingularityContainers` was expecting a `.img` file, but since we're now using the correct `.simg` extension for singularity images, it was an issue
 
## PR checklist
 - [x] PR is made against `dev` branch
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [x] `CHANGELOG.md` is updated