### PR TITLE
Add genome_base for human reference genomes to CFC config

### DIFF
--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -19,4 +19,5 @@ params {
   max_memory = 60.GB
   max_cpus = 20
   max_time = 140.h
+  genome_base = '/sfs/4/qbic/references/human'
 }


### PR DESCRIPTION
## PR checklist
 - [x] PR is made against `dev` branch
 - [ ] PR is a hotfix against `master` branch
 - [x] This comment contains a description of changes (with reason)

This just updates our configuration `genome_base` reference genome library path, so that people just have to specify against which genome they want to run things. 

