### PR TITLE
Move `check_max` function to `nextflow.config`

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -70,35 +70,3 @@ trace { // Turning on trace tracking by default
   file = "${params.outDir}/Reports/Sarek_trace.txt"
 }
 
-// Function to ensure that resource requirements don't go beyond
-// a maximum limit
-def check_max(obj, type) {
-  if(type == 'memory'){
-    try {
-      if(obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-        return params.max_memory as nextflow.util.MemoryUnit
-      else
-        return obj
-    } catch (all) {
-      println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
-      return obj
-    }
-  } else if(type == 'time'){
-    try {
-      if(obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-        return params.max_time as nextflow.util.Duration
-      else
-        return obj
-    } catch (all) {
-      println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
-      return obj
-    }
-  } else if(type == 'cpus'){
-    try {
-      return Math.min( obj, params.max_cpus as int )
-    } catch (all) {
-      println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
-      return obj
-    }
-  }
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -98,5 +98,38 @@ profiles {
     includeConfig 'conf/resources.config'
     includeConfig 'conf/containers.config'
   }
+}
 
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+  if(type == 'memory'){
+    try {
+      if(obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+        return params.max_memory as nextflow.util.MemoryUnit
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if(type == 'time'){
+    try {
+      if(obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+        return params.max_time as nextflow.util.Duration
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if(type == 'cpus'){
+    try {
+      return Math.min( obj, params.max_cpus as int )
+    } catch (all) {
+      println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+      return obj
+    }
+  }
 }


### PR DESCRIPTION
This moves the `check_max` function to the main `nextflow.config`. We had issues when using the current `cfc` profile on our cluster to resolve the function properly, thus creating errors such as this one:

```
Completed at: Fri Nov 02 10:10:45 CET 2018
Duration    : 6s
Success     : false
Exit status : null
Error report: Error executing process > 'MapReads (QMSHSENTITY-2-_L004_)'

Caused by:
 No signature of method: _nf_script_64002d7c.check_max() is applicable for argument types: (Integer, String) values: [10, cpus]
```

Manually adding the function to `nextflow.config` resolved the error for us. 


## PR checklist
 - [x] PR is made against `dev` branch
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!