### PR TITLE
fix PublishDir for some process

### DIFF
--- a/annotate.nf
+++ b/annotate.nf
@@ -146,9 +146,9 @@ process RunSnpeff {
   tag {"${variantCaller} - ${vcf}"}
 
   publishDir params.outDir, mode: params.publishDirMode, saveAs: {
-    if (it == "${vcf.simpleName}_snpEff.csv") "${directoryMap.snpeffReports}/${it}"
+    if (it == "${vcf.simpleName}_snpEff.csv") "${directoryMap.snpeffReports.minus(params.outDir+'/')}/${it}"
     else if (it == "${vcf.simpleName}_snpEff.ann.vcf") null
-    else "${directoryMap.snpeff}/${it}"
+    else "${directoryMap.snpeff.minus(params.outDir+'/')}/${it}"
   }
 
   input:
@@ -199,7 +199,7 @@ process RunVEP {
   tag {"${variantCaller} - ${vcf}"}
 
   publishDir params.outDir, mode: params.publishDirMode, saveAs: {
-    if (it == "${vcf.simpleName}_VEP.summary.html") "${directoryMap.vep}/${it}"
+    if (it == "${vcf.simpleName}_VEP.summary.html") "${directoryMap.vep.minus(params.outDir+'/')}/${it}"
     else null
   }
 

--- a/main.nf
+++ b/main.nf
@@ -228,8 +228,8 @@ process MarkDuplicates {
 
   publishDir params.outDir, mode: params.publishDirMode,
     saveAs: {
-      if (it == "${bam}.metrics") "${directoryMap.markDuplicatesQC}/${it}"
-      else "${directoryMap.duplicateMarked}/${it}"
+      if (it == "${idSample}.bam.metrics") "${directoryMap.markDuplicatesQC.minus(params.outDir+'/')}/${it}"
+      else "${directoryMap.duplicateMarked.minus(params.outDir+'/')}/${it}"
     }
 
   input:


### PR DESCRIPTION
outDir was in fact used twice in PublishDir for some process

## PR checklist
 - [x] PR is made against `dev` branch
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] `CHANGELOG.md` is updated