### PR TITLE
replace --TMP_DIR by --tmp-dir in BaseRecalibrator to close #704

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   [#693](https://github.com/SciLifeLab/Sarek/pull/693) - Qualimap bamQC is now ran after mapping and after recalibration for better QC
 -   [#700](https://github.com/SciLifeLab/Sarek/pull/700) - Update GATK to `4.0.9.0`
 -   [#702](https://github.com/SciLifeLab/Sarek/pull/702) - update FastQC to `0.11.8`
+-   [#705](https://github.com/SciLifeLab/Sarek/pull/705) - Change `--TMP_DIR` by `--tmp-dir` for GATK `4.0.9.0` BaseRecalibrator
 
 ### `Fixed`
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   [#679](https://github.com/SciLifeLab/Sarek/pull/679) - Add publishDirMode for `germlineVC.nf`
 -   [#700](https://github.com/SciLifeLab/Sarek/pull/700) - Fix [#699](https://github.com/SciLifeLab/Sarek/issues/699) missing DP in the FORMAT column VCFs for MuTect2
 -   [#702](https://github.com/SciLifeLab/Sarek/pull/702) - Fix [#701](https://github.com/SciLifeLab/Sarek/issues/701)
+-   [#705](https://github.com/SciLifeLab/Sarek/pull/705) - Fix [#704](https://github.com/SciLifeLab/Sarek/issues/704)
 
 ## [2.2.1] - 2018-10-04
 

--- a/main.nf
+++ b/main.nf
@@ -352,7 +352,7 @@ process CreateRecalibrationTable {
   BaseRecalibrator \
   --input ${bam} \
   --output ${idSample}.recal.table \
-	--TMP_DIR /tmp \
+  --tmp-dir /tmp \
   -R ${genomeFile} \
   -L ${intervals} \
   --known-sites ${dbsnp} \
@@ -418,8 +418,8 @@ process RecalibrateBam {
   --input ${bam} \
   --output ${idSample}.recal.bam \
   -L ${intervals} \
-	--create-output-bam-index true \
-	--bqsr-recal-file ${recalibrationReport}
+  --create-output-bam-index true \
+  --bqsr-recal-file ${recalibrationReport}
   """
 }
 // Creating a TSV file to restart from this step


### PR DESCRIPTION
- Fix #704 
- `--TMP_DIR` was replaced by `--tmp-dir` at some point between GATK `4.0.6.0` and `4.0.9.0`

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [x] `CHANGELOG.md` is updated