### PR TITLE
Run bamQC on the recalibrated BAMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Removed`
 -   [#715](https://github.com/SciLifeLab/Sarek/pull/715) - Remove `defReferencesFiles` function from `buildReferences.nf`
 
+### `Fixed`
+-   [#720](https://github.com/SciLifeLab/Sarek/pull/720) - bamQC is now run on the recalibrated bams, and not after MarkDuplicates
+
 ## [2.2.2] - 2018-12-19
 
 ### `Added`

--- a/main.nf
+++ b/main.nf
@@ -379,15 +379,6 @@ if (params.verbose) recalibrationTable = recalibrationTable.view {
   Files : [${it[3].fileName}, ${it[4].fileName}, ${it[5].fileName}]"
 }
 
-(bamForBamQC, bamForSamToolsStats, recalTables, recalibrationTableForHC, recalibrationTable) = recalibrationTable.into(5)
-
-// Remove recalTable from Channels to match inputs for Process to avoid:
-// WARN: Input tuple does not match input set cardinality declared by process...
-bamForBamQC = bamForBamQC.map { it[0..4] }
-bamForSamToolsStats = bamForSamToolsStats.map{ it[0..4] }
-
-recalTables = recalTables.map { [it[0]] + it[2..-1] } // remove status
-
 process RecalibrateBam {
   tag {idPatient + "-" + idSample}
 
@@ -406,8 +397,6 @@ process RecalibrateBam {
     set idPatient, status, idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bai") into recalibratedBam, recalibratedBamForStats
     set idPatient, status, idSample, val("${idSample}.recal.bam"), val("${idSample}.recal.bai") into recalibratedBamTSV
 
-  // GATK4 HaplotypeCaller can not do BQSR on the fly, so we have to create a
-  // recalibrated BAM explicitly.
   when: !params.onlyQC
 
   script:
@@ -435,6 +424,10 @@ if (params.verbose) recalibratedBam = recalibratedBam.view {
   ID    : ${it[0]}\tStatus: ${it[1]}\tSample: ${it[2]}\n\
   Files : [${it[3].fileName}, ${it[4].fileName}]"
 }
+
+// Remove recalTable from Channels to match inputs for Process to avoid:
+// WARN: Input tuple does not match input set cardinality declared by process...
+(bamForBamQC, bamForSamToolsStats) = recalibratedBamForStats.map{ it[0..4] }.into(2)
 
 process RunSamtoolsStats {
   tag {idPatient + "-" + idSample}


### PR DESCRIPTION
- removed old channels and comments
- The second BamQC (and samtools stats) are now run on the recalibrated BAMs (before it was on the MarkDuplicates)

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [X] `CHANGELOG.md` is updated