### PR TITLE
fix input for RunAscat (was not a set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 -   [#720](https://github.com/SciLifeLab/Sarek/pull/720) - bamQC is now run on the recalibrated bams, and not after MarkDuplicates
+-   [#726](https://github.com/SciLifeLab/Sarek/pull/726) - Fix Ascat ref file input (one file can't be a set)
 
 ## [2.2.2] - 2018-12-19
 

--- a/somaticVC.nf
+++ b/somaticVC.nf
@@ -640,7 +640,7 @@ process RunAscat {
 
   input:
     set idPatient, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
-    set file(acLociGC) from Channel.value([referenceMap.acLociGC])
+    file(acLociGC) from Channel.value([referenceMap.acLociGC])
 
   output:
     set val("ascat"), idPatient, idSampleNormal, idSampleTumor, file("${idSampleTumor}.*.{png,txt}") into ascatOutput


### PR DESCRIPTION
- Fix Ascat ref file input (one file can't be a set)

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [x] `CHANGELOG.md` is updated