### PR TITLE
update cfc and binac genome_base and singularity version

### DIFF
--- a/conf/binac.config
+++ b/conf/binac.config
@@ -3,6 +3,7 @@
  *  Nextflow config file for use with Singularity on BINAC cluster in Tuebingen
  * ----------------------------------------------------------------------------
  * Defines basic usage limits and singularity image id.
+ * Sets genome_base to local igenomes directory
  */
 
 singularity {
@@ -10,14 +11,15 @@ singularity {
 }
 
 process {
-    beforeScript = 'module load devel/singularity/2.6.0'
+    beforeScript = 'module load devel/singularity/3.0.1'
     executor = 'pbs'
     queue = 'short'
 }
 
 params {
-  publishDirMode = 'symlink' 
+  publishDirMode = 'symlink'
   max_memory = 128.GB
   max_cpus = 28
   max_time = 48.h
+  params.genome == 'GRCh37' ? '/nfsmounts/igenomes/Homo_sapiens/GATK/GRCh37' : params.genome == 'GRCh38' ? '/nfsmounts/igenomes/Homo_sapiens/GATK/GRCh38' : 'References/smallGRCh37'
 }

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -3,6 +3,7 @@
  *  Nextflow config file for use with Singularity on CFC at QBIC
  * -------------------------------------------------------------
  * Defines basic usage limits and singularity image id.
+ * Sets genome_base to local igenomes directory
  */
 
 /*
@@ -10,14 +11,14 @@
 */
 
 process {
-  beforeScript = 'module load qbic/singularity_slurm/2.5.2'
+  beforeScript = 'module load qbic/singularity_slurm/3.0.3'
   executor = 'slurm'
 }
 
 params {
-  publishDirMode = 'symlink' 
+  publishDirMode = 'symlink'
   max_memory = 60.GB
   max_cpus = 20
   max_time = 140.h
-  genome_base = '/sfs/4/qbic/references/human'
+  params.genome == 'GRCh37' ? '/nfsmounts/igenomes/Homo_sapiens/GATK/GRCh37' : params.genome == 'GRCh38' ? '/nfsmounts/igenomes/Homo_sapiens/GATK/GRCh38' : 'References/smallGRCh37'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,7 +39,7 @@ profiles {
   binac {
     includeConfig 'conf/base.config'
     includeConfig 'conf/binac.config'
-    includeConfig 'conf/genomes.config'
+    includeConfig 'conf/igenomes.config'
     includeConfig 'conf/singularity.config'
     includeConfig 'conf/resources.config'
     includeConfig 'conf/containers.config'
@@ -57,10 +57,19 @@ profiles {
   cfc {
     includeConfig 'conf/base.config'
     includeConfig 'conf/cfc.config'
-    includeConfig 'conf/genomes.config'
+    includeConfig 'conf/igenomes.config'
     includeConfig 'conf/singularity.config'
     includeConfig 'conf/resources.config'
     includeConfig 'conf/containers.config'
+  }
+  // Defines a conda environment.yml file in the current directory.
+  // Careful when using it with other profiles as it might overwrite
+  // the genomes/igenomes.config
+  conda {
+    includeConfig 'conf/base.config'
+    includeConfig 'conf/travis.config'
+    includeConfig 'conf/genomes.config'
+    includeConfig 'conf/conda.config'
   }
   // Small testing with Docker profile
   // Docker images will be pulled automatically
@@ -105,12 +114,6 @@ profiles {
     includeConfig 'conf/uppmax-localhost.config'
     includeConfig 'conf/genomes.config'
     includeConfig 'conf/singularity-path.config'
-  }
-  conda {
-    includeConfig 'conf/base.config'
-    includeConfig 'conf/travis.config'
-    includeConfig 'conf/genomes.config'
-    includeConfig 'conf/conda.config'
   }
 }
 


### PR DESCRIPTION
## Update `genome_base` and singularity version for `cfc` and `binac`
This PR aims to update the `cfc.config` and the `binac.config` to set a genome_base and `nextflow.config` to allow `cfc` and `binac` to use an `igenomes` setup.

## PR checklist
 - [x] PR is made against `dev` branch
 - [ ] PR is a hotfix against `master` branch
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/SciLifeLab/Sarek/blob/master/.github/CONTRIBUTING.md
