### PR TITLE
add minimal process.cpu .mem and .time definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 -   [#749](https://github.com/SciLifeLab/Sarek/pull/749) - Fix config problematic use of queue `core` for uppmax-slurm
+-   [#760](https://github.com/SciLifeLab/Sarek/pull/749) - Fix undefined `task.mem`
 
 ## [2.3.FIX1] - 2019-03-04
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -42,6 +42,11 @@ params {
 }
 
 process {
+  // set minimal values in case there is no other specification -> prevent task.* to be Null
+  cpus = { check_max( 1 * task.attempt, 'cpus' ) }
+  memory = { check_max( 2.GB * task.attempt, 'memory' ) }
+  time = { check_max( 2.h * task.attempt, 'time' ) }
+
   withName:ConcatVCF {
     // For unknown reasons, ConcatVCF sometimes fails with SIGPIPE
     // (exit code 141). Rerunning the process will usually work.


### PR DESCRIPTION
## Fix Scripting Bug

Currently there are references to `task.mem` in the script sections e.g. for `HaplotypeCaller`. 

When a local standard executor is used or when there is no definition of the process attributes in the configuration files `task.mem` is `null`. 
Therefore functions such as `task.mem.toGiga()` fail.

To fix this behaviour this PR includes a minimal definition for process resources. 

## PR checklist
 - [x] PR is made against `dev` branch
 - [ ] PR is a hotfix against `master` branch
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/SciLifeLab/Sarek/blob/master/.github/CONTRIBUTING.md
