### PR TITLE
add sorted list of empty process resource specification to the

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -43,139 +43,137 @@ params {
 
 process {
 
+  //## appearing in multiple .nf scripts
+  // - `RunBcftoolsStats` - Run BCFTools stats on vcf files
+  withName: RunBcftoolsStats {}
+  // - `RunVcftools` - Run VCFTools on vcf files
+  withName: RunVcftools {}
+  // - `CreateIntervalBeds` - Create and sort intervals into bed files
+  withName: CreateIntervalBeds {}
+  // - `ConcatVCF` - Merge results from paralellized callers
+  withName: ConcatVCF {
+    // For unknown reasons, ConcatVCF sometimes fails with SIGPIPE
+    // (exit code 141). Rerunning the process will usually work.
+    errorStrategy = {task.exitStatus == 141 ? 'retry' : 'terminate'}
+  }
+  // - `RunSingleManta` - Run Manta for Single Structural Variant Calling
+  withName: RunSingleManta {}
 
-//## appearing in multiple .nf scripts
-    // - `RunBcftoolsStats` - Run BCFTools stats on vcf files
-    withName:RunBcftoolsStats {}
-    // - `RunVcftools` - Run VCFTools on vcf files
-    withName:RunVcftools {}
-    // - `CreateIntervalBeds` - Create and sort intervals into bed files
-    withName:CreateIntervalBeds {}
-    // - `ConcatVCF` - Merge results from paralellized callers
-    withName:ConcatVCF {
-        // For unknown reasons, ConcatVCF sometimes fails with SIGPIPE
-        // (exit code 141). Rerunning the process will usually work.
-        errorStrategy = {task.exitStatus == 141 ? 'retry' : 'terminate'}
-    }
-    // - `RunSingleManta` - Run Manta for Single Structural Variant Calling
-    withName:RunSingleManta {}
-
-//## `annotate.nf`
-//
-// - `RunBcftoolsStats` - Run BCFTools stats on vcf files
-    //withName:RunBcftoolsStats {}
-// - `RunVcftools` - Run VCFTools on vcf files
-    //withName:RunVcftools {}
-// - `RunSnpeff` - Run snpEff for annotation of vcf files
-    withName:RunSnpeff {}
-// - `RunVEP` - Run VEP for annotation of vcf files
-    withName:RunVEP {}
-// - `CompressVCF` - Compress and index vcf files using tabix
-    withName:CompressVCF {}
-//
-//## `build.nf`
-//
-// - `BuildWithDocker` - Build containers using Docker
-    withName:BuildWithDocker {}
-// - `PullToSingularity` - Pull Singularity containers from Docker Hub
-    withName:PullToSingularity {}
-// - `PushToDocker` - Push containers to Docker Hub
-    withName:PushToDocker {}
-// - `DecompressFile` - Extract files if needed
-    withName:DecompressFile {}
-// - `BuildBWAindexes` - Build indexes for BWA
-    withName:BuildBWAindexes {}
-// - `BuildReferenceIndex` - Build index for FASTA refs
-    withName:BuildReferenceIndex {}
-// - `BuildSAMToolsIndex` - Build index with SAMTools
-    withName:BuildSAMToolsIndex {}
-// - `BuildVCFIndex` - Build index for VCF files
-    withName:BuildVCFIndex {}
-// - `BuildCache_snpEff` - Download Cache for snpEff
-    withName:BuildCache_snpEff {}
-// - `BuildCache_VEP` - Download taqbix index Cache for VEP
-    withName:BuildCache_VEP {}
-//
-//## `main.nf`
-//
-//- `RunFastQC` - Run FastQC for QC on fastq files
-    withName:RunFastQC {}
-// - `MapReads` - Map reads with BWA
-    withName:MapReads {}
-// - `MergeBams` - Merge BAMs if multilane samples
-    withName:MergeBams {}
-// - `MarkDuplicates` - Mark Duplicates with GATK4
-    withName:MarkDuplicates {}
-// - `CreateRecalibrationTable` - Create Recalibration Table with BaseRecalibrator
-    withName:CreateRecalibrationTable {}
-// - `RecalibrateBam` - Recalibrate Bam with PrintReads
-    withName:RecalibrateBam {}
-// - `RunSamtoolsStats` - Run Samtools stats on recalibrated BAM files
-    withName:RunSamtoolsStats {}
-// - `RunBamQCmapped` - Run qualimap BamQC on mapped BAM files
-    withName:RunBamQCmapped {}
-// - `RunBamQCrecalibrated` - Run qualimap BamQC on recalibrated BAM files
-    withName:RunBamQCrecalibrated {}
-//
-//## `germlineVC.nf`
-//
-// - `CreateIntervalBeds` - Create and sort intervals into bed files
-    //withName:CreateIntervalBeds {}
-// - `RunHaplotypecaller` - Run HaplotypeCaller for Germline Variant Calling (Parallelized processes)
-    withName:RunHaplotypecaller {}
-// - `RunGenotypeGVCFs` - Run HaplotypeCaller for Germline Variant Calling (Parallelized processes)
-    withName:RunGenotypeGVCFs {}
-// - `ConcatVCF` - Merge results from paralellized callers
-    //withName:ConcatVCF {}
-// - `RunSingleStrelka` - Run Strelka for Germline Variant Calling
-    withName:RunSingleStrelka {}
-// - `RunSingleManta` - Run Manta for Single Structural Variant Calling
-    //withName:RunSingleManta {}
-// - `RunBcftoolsStats` - Run BCTools stats on vcf files
-    //withName:RunBcftoolsStats {}
-// - `RunVcftools` - Run VCFTools on vcf files
-    //withName:RunVcftools {}
-//
-//## `somaticVC.nf`
-//
-// - `CreateIntervalBeds` - Create and sort intervals into bed files
-    //withName:CreateIntervalBeds {}
-// - `RunMutect2` - Run MuTect2 for Variant Calling (Parallelized processes)
-    withName:RunMutect2 {}
-// - `RunFreeBayes` - Run FreeBayes for Variant Calling (Parallelized processes)
-    withName:RunFreeBayes {}
-// - `ConcatVCF` - Merge results from paralellized variant callers
-    //withName:ConcatVCF {}
-// - `RunStrelka` - Run Strelka for Variant Calling
-    withName:RunStrelka {}
-// - `RunStrelkaBP` - Run Strelka Best Practices for Variant Calling
-    withName:RunStrelkaBP {}
-// - `RunManta` - Run Manta for Structural Variant Calling
-    withName:RunManta {}
-// - `RunSingleManta` - Run Manta for Single Structural Variant Calling
-    //withName:RunSingleManta {}
-// - `RunAlleleCount` - Run AlleleCount to prepare for ASCAT
-    withName:RunAlleleCount {}
-// - `RunConvertAlleleCounts` - Run convertAlleleCounts to prepare for ASCAT
-    withName:RunConvertAlleleCounts {}
-// - `RunAscat` - Run ASCAT for CNV
-    withName:RunAscat {}
-// - `RunBcftoolsStats` - Run BCFTools stats on vcf files
-    //withName:RunBcftoolsStats {}
-// - `RunVcftools` - Run VCFTools on vcf files
-    //withName:RunVcftools {}
-// - `GetVersionAlleleCount` - Get version of tools
-    withName:GetVersionAlleleCount {}
-// - `GetVersionASCAT` - Get version of tools
-    withName:GetVersionASCAT {}
-//
-//## `runMultiQC.nf`
-//
-// - `GetVersionAll` - Get version of tools
-    withName:GetVersionAll {}
-// - `RunMultiQC` - Run MultiQC on reports
-    withName:RunMultiQC {}
-
+  //## `annotate.nf`
+  //
+  // - `RunBcftoolsStats` - Run BCFTools stats on vcf files
+  //withName: RunBcftoolsStats {}
+  // - `RunVcftools` - Run VCFTools on vcf files
+  //withName: RunVcftools {}
+  // - `RunSnpeff` - Run snpEff for annotation of vcf files
+  withName: RunSnpeff {}
+  // - `RunVEP` - Run VEP for annotation of vcf files
+  withName: RunVEP {}
+  // - `CompressVCF` - Compress and index vcf files using tabix
+  withName: CompressVCF {}
+  //
+  //## `build.nf`
+  //
+  // - `BuildWithDocker` - Build containers using Docker
+  withName: BuildWithDocker {}
+  // - `PullToSingularity` - Pull Singularity containers from Docker Hub
+  withName: PullToSingularity {}
+  // - `PushToDocker` - Push containers to Docker Hub
+  withName: PushToDocker {}
+  // - `DecompressFile` - Extract files if needed
+  withName: DecompressFile {}
+  // - `BuildBWAindexes` - Build indexes for BWA
+  withName: BuildBWAindexes {}
+  // - `BuildReferenceIndex` - Build index for FASTA refs
+  withName: BuildReferenceIndex {}
+  // - `BuildSAMToolsIndex` - Build index with SAMTools
+  withName: BuildSAMToolsIndex {}
+  // - `BuildVCFIndex` - Build index for VCF files
+  withName: BuildVCFIndex {}
+  // - `BuildCache_snpEff` - Download Cache for snpEff
+  withName: BuildCache_snpEff {}
+  // - `BuildCache_VEP` - Download taqbix index Cache for VEP
+  withName: BuildCache_VEP {}
+  //
+  //## `main.nf`
+  //
+  //- `RunFastQC` - Run FastQC for QC on fastq files
+  withName: RunFastQC {}
+  // - `MapReads` - Map reads with BWA
+  withName: MapReads {}
+  // - `MergeBams` - Merge BAMs if multilane samples
+  withName: MergeBams {}
+  // - `MarkDuplicates` - Mark Duplicates with GATK4
+  withName: MarkDuplicates {}
+  // - `CreateRecalibrationTable` - Create Recalibration Table with BaseRecalibrator
+  withName: CreateRecalibrationTable {}
+  // - `RecalibrateBam` - Recalibrate Bam with PrintReads
+  withName: RecalibrateBam {}
+  // - `RunSamtoolsStats` - Run Samtools stats on recalibrated BAM files
+  withName: RunSamtoolsStats {}
+  // - `RunBamQCmapped` - Run qualimap BamQC on mapped BAM files
+  withName: RunBamQCmapped {}
+  // - `RunBamQCrecalibrated` - Run qualimap BamQC on recalibrated BAM files
+  withName: RunBamQCrecalibrated {}
+  //
+  //## `germlineVC.nf`
+  //
+  // - `CreateIntervalBeds` - Create and sort intervals into bed files
+  //withName: CreateIntervalBeds {}
+  // - `RunHaplotypecaller` - Run HaplotypeCaller for Germline Variant Calling (Parallelized processes)
+  withName: RunHaplotypecaller {}
+  // - `RunGenotypeGVCFs` - Run HaplotypeCaller for Germline Variant Calling (Parallelized processes)
+  withName: RunGenotypeGVCFs {}
+  // - `ConcatVCF` - Merge results from paralellized callers
+  //withName: ConcatVCF {}
+  // - `RunSingleStrelka` - Run Strelka for Germline Variant Calling
+  withName: RunSingleStrelka {}
+  // - `RunSingleManta` - Run Manta for Single Structural Variant Calling
+  //withName: RunSingleManta {}
+  // - `RunBcftoolsStats` - Run BCTools stats on vcf files
+  //withName: RunBcftoolsStats {}
+  // - `RunVcftools` - Run VCFTools on vcf files
+  //withName: RunVcftools {}
+  //
+  //## `somaticVC.nf`
+  //
+  // - `CreateIntervalBeds` - Create and sort intervals into bed files
+  //withName: CreateIntervalBeds {}
+  // - `RunMutect2` - Run MuTect2 for Variant Calling (Parallelized processes)
+  withName: RunMutect2 {}
+  // - `RunFreeBayes` - Run FreeBayes for Variant Calling (Parallelized processes)
+  withName: RunFreeBayes {}
+  // - `ConcatVCF` - Merge results from paralellized variant callers
+  //withName: ConcatVCF {}
+  // - `RunStrelka` - Run Strelka for Variant Calling
+  withName: RunStrelka {}
+  // - `RunStrelkaBP` - Run Strelka Best Practices for Variant Calling
+  withName: RunStrelkaBP {}
+  // - `RunManta` - Run Manta for Structural Variant Calling
+  withName: RunManta {}
+  // - `RunSingleManta` - Run Manta for Single Structural Variant Calling
+  //withName: RunSingleManta {}
+  // - `RunAlleleCount` - Run AlleleCount to prepare for ASCAT
+  withName: RunAlleleCount {}
+  // - `RunConvertAlleleCounts` - Run convertAlleleCounts to prepare for ASCAT
+  withName: RunConvertAlleleCounts {}
+  // - `RunAscat` - Run ASCAT for CNV
+  withName: RunAscat {}
+  // - `RunBcftoolsStats` - Run BCFTools stats on vcf files
+  //withName: RunBcftoolsStats {}
+  // - `RunVcftools` - Run VCFTools on vcf files
+  //withName: RunVcftools {}
+  // - `GetVersionAlleleCount` - Get version of tools
+  withName: GetVersionAlleleCount {}
+  // - `GetVersionASCAT` - Get version of tools
+  withName: GetVersionASCAT {}
+  //
+  //## `runMultiQC.nf`
+  //
+  // - `GetVersionAll` - Get version of tools
+  withName: GetVersionAll {}
+  // - `RunMultiQC` - Run MultiQC on reports
+  withName: RunMultiQC {}
 }
 
 process.shell = ['/bin/bash', '-euo', 'pipefail']

--- a/conf/base.config
+++ b/conf/base.config
@@ -76,29 +76,6 @@ process {
   // - `CompressVCF` - Compress and index vcf files using tabix
   withName: CompressVCF {}
   //
-  //## `build.nf`
-  //
-  // - `BuildWithDocker` - Build containers using Docker
-  withName: BuildWithDocker {}
-  // - `PullToSingularity` - Pull Singularity containers from Docker Hub
-  withName: PullToSingularity {}
-  // - `PushToDocker` - Push containers to Docker Hub
-  withName: PushToDocker {}
-  // - `DecompressFile` - Extract files if needed
-  withName: DecompressFile {}
-  // - `BuildBWAindexes` - Build indexes for BWA
-  withName: BuildBWAindexes {}
-  // - `BuildReferenceIndex` - Build index for FASTA refs
-  withName: BuildReferenceIndex {}
-  // - `BuildSAMToolsIndex` - Build index with SAMTools
-  withName: BuildSAMToolsIndex {}
-  // - `BuildVCFIndex` - Build index for VCF files
-  withName: BuildVCFIndex {}
-  // - `BuildCache_snpEff` - Download Cache for snpEff
-  withName: BuildCache_snpEff {}
-  // - `BuildCache_VEP` - Download taqbix index Cache for VEP
-  withName: BuildCache_VEP {}
-  //
   //## `main.nf`
   //
   //- `RunFastQC` - Run FastQC for QC on fastq files

--- a/conf/base.config
+++ b/conf/base.config
@@ -42,11 +42,143 @@ params {
 }
 
 process {
-  withName:ConcatVCF {
-    // For unknown reasons, ConcatVCF sometimes fails with SIGPIPE
-    // (exit code 141). Rerunning the process will usually work.
-    errorStrategy = {task.exitStatus == 141 ? 'retry' : 'terminate'}
-  }
+
+
+//## appearing in multiple .nf scripts
+    // - `RunBcftoolsStats` - Run BCFTools stats on vcf files
+    withName:RunBcftoolsStats {}
+    // - `RunVcftools` - Run VCFTools on vcf files
+    withName:RunVcftools {}
+    // - `CreateIntervalBeds` - Create and sort intervals into bed files
+    withName:CreateIntervalBeds {}
+    // - `ConcatVCF` - Merge results from paralellized callers
+    withName:ConcatVCF {
+        // For unknown reasons, ConcatVCF sometimes fails with SIGPIPE
+        // (exit code 141). Rerunning the process will usually work.
+        errorStrategy = {task.exitStatus == 141 ? 'retry' : 'terminate'}
+    }
+    // - `RunSingleManta` - Run Manta for Single Structural Variant Calling
+    withName:RunSingleManta {}
+
+//## `annotate.nf`
+//
+// - `RunBcftoolsStats` - Run BCFTools stats on vcf files
+    //withName:RunBcftoolsStats {}
+// - `RunVcftools` - Run VCFTools on vcf files
+    //withName:RunVcftools {}
+// - `RunSnpeff` - Run snpEff for annotation of vcf files
+    withName:RunSnpeff {}
+// - `RunVEP` - Run VEP for annotation of vcf files
+    withName:RunVEP {}
+// - `CompressVCF` - Compress and index vcf files using tabix
+    withName:CompressVCF {}
+// - `GetVersionSnpeff` - Get version of tools
+    withName:GetVersionSnpeff {}
+// - `GetVersionVEP` - Get version of tools
+    withName:GetVersionVEP {}
+//
+//## `buildContainers.nf`
+//
+// - `BuildDockerContainers` - Build containers using Docker
+    withName:BuildDockerContainers {}
+// - `PullSingularityContainers` - Pull Singularity containers from Docker Hub
+    withName:PullSingularityContainers {}
+// - `PushDockerContainers` - Push containers to Docker Hub
+    withName:PushDockerContainers {}
+//
+//## `buildReferences.nf`
+//
+// - `DecompressFile` - Extract files if needed
+    withName:DecompressFile {}
+// - `BuildBWAindexes` - Build indexes for BWA
+    withName:BuildBWAindexes {}
+// - `BuildReferenceIndex` - Build index for FASTA refs
+    withName:BuildReferenceIndex {}
+// - `BuildSAMToolsIndex` - Build index with SAMTools
+    withName:BuildSAMToolsIndex {}
+// - `BuildVCFIndex` - Build index for VCF files
+    withName:BuildVCFIndex {}
+//
+//## `main.nf`
+//
+//- `RunFastQC` - Run FastQC for QC on fastq files
+    withName:RunFastQC {}
+// - `MapReads` - Map reads with BWA
+    withName:MapReads {}
+// - `MergeBams` - Merge BAMs if multilane samples
+    withName:MergeBams {}
+// - `MarkDuplicates` - Mark Duplicates with GATK4
+    withName:MarkDuplicates {}
+// - `CreateRecalibrationTable` - Create Recalibration Table with BaseRecalibrator
+    withName:CreateRecalibrationTable {}
+// - `RecalibrateBam` - Recalibrate Bam with PrintReads
+    withName:RecalibrateBam {}
+// - `RunSamtoolsStats` - Run Samtools stats on recalibrated BAM files
+    withName:RunSamtoolsStats {}
+// - `RunBamQCmapped` - Run qualimap BamQC on mapped BAM files
+    withName:RunBamQCmapped {}
+// - `RunBamQCrecalibrated` - Run qualimap BamQC on recalibrated BAM files
+    withName:RunBamQCrecalibrated {}
+//
+//## `germlineVC.nf`
+//
+// - `CreateIntervalBeds` - Create and sort intervals into bed files
+    //withName:CreateIntervalBeds {}
+// - `RunHaplotypecaller` - Run HaplotypeCaller for Germline Variant Calling (Parallelized processes)
+    withName:RunHaplotypecaller {}
+// - `RunGenotypeGVCFs` - Run HaplotypeCaller for Germline Variant Calling (Parallelized processes)
+    withName:RunGenotypeGVCFs {}
+// - `ConcatVCF` - Merge results from paralellized callers
+    //withName:ConcatVCF {}
+// - `RunSingleStrelka` - Run Strelka for Germline Variant Calling
+    withName:RunSingleStrelka {}
+// - `RunSingleManta` - Run Manta for Single Structural Variant Calling
+    //withName:RunSingleManta {}
+// - `RunBcftoolsStats` - Run BCTools stats on vcf files
+    //withName:RunBcftoolsStats {}
+// - `RunVcftools` - Run VCFTools on vcf files
+    //withName:RunVcftools {}
+//
+//## `somaticVC.nf`
+//
+// - `CreateIntervalBeds` - Create and sort intervals into bed files
+    //withName:CreateIntervalBeds {}
+// - `RunMutect2` - Run MuTect2 for Variant Calling (Parallelized processes)
+    withName:RunMutect2 {}
+// - `RunFreeBayes` - Run FreeBayes for Variant Calling (Parallelized processes)
+    withName:RunFreeBayes {}
+// - `ConcatVCF` - Merge results from paralellized variant callers
+    //withName:ConcatVCF {}
+// - `RunStrelka` - Run Strelka for Variant Calling
+    withName:RunStrelka {}
+// - `RunStrelkaBP` - Run Strelka Best Practices for Variant Calling
+    withName:RunStrelkaBP {}
+// - `RunManta` - Run Manta for Structural Variant Calling
+    withName:RunManta {}
+// - `RunSingleManta` - Run Manta for Single Structural Variant Calling
+    //withName:RunSingleManta {}
+// - `RunAlleleCount` - Run AlleleCount to prepare for ASCAT
+    withName:RunAlleleCount {}
+// - `RunConvertAlleleCounts` - Run convertAlleleCounts to prepare for ASCAT
+    withName:RunConvertAlleleCounts {}
+// - `RunAscat` - Run ASCAT for CNV
+    withName:RunAscat {}
+// - `RunBcftoolsStats` - Run BCFTools stats on vcf files
+    //withName:RunBcftoolsStats {}
+// - `RunVcftools` - Run VCFTools on vcf files
+    //withName:RunVcftools {}
+// - `GetVersionAlleleCount` - Get version of tools
+    withName:GetVersionAlleleCount {}
+// - `GetVersionASCAT` - Get version of tools
+    withName:GetVersionASCAT {}
+//
+//## `runMultiQC.nf`
+//
+// - `GetVersionAll` - Get version of tools
+    withName:GetVersionAll {}
+// - `RunMultiQC` - Run MultiQC on reports
+    withName:RunMultiQC {}
+
 }
 
 process.shell = ['/bin/bash', '-euo', 'pipefail']

--- a/conf/base.config
+++ b/conf/base.config
@@ -72,22 +72,15 @@ process {
     withName:RunVEP {}
 // - `CompressVCF` - Compress and index vcf files using tabix
     withName:CompressVCF {}
-// - `GetVersionSnpeff` - Get version of tools
-    withName:GetVersionSnpeff {}
-// - `GetVersionVEP` - Get version of tools
-    withName:GetVersionVEP {}
 //
-//## `buildContainers.nf`
+//## `build.nf`
 //
-// - `BuildDockerContainers` - Build containers using Docker
-    withName:BuildDockerContainers {}
-// - `PullSingularityContainers` - Pull Singularity containers from Docker Hub
-    withName:PullSingularityContainers {}
-// - `PushDockerContainers` - Push containers to Docker Hub
-    withName:PushDockerContainers {}
-//
-//## `buildReferences.nf`
-//
+// - `BuildWithDocker` - Build containers using Docker
+    withName:BuildWithDocker {}
+// - `PullToSingularity` - Pull Singularity containers from Docker Hub
+    withName:PullToSingularity {}
+// - `PushToDocker` - Push containers to Docker Hub
+    withName:PushToDocker {}
 // - `DecompressFile` - Extract files if needed
     withName:DecompressFile {}
 // - `BuildBWAindexes` - Build indexes for BWA
@@ -98,6 +91,10 @@ process {
     withName:BuildSAMToolsIndex {}
 // - `BuildVCFIndex` - Build index for VCF files
     withName:BuildVCFIndex {}
+// - `BuildCache_snpEff` - Download Cache for snpEff
+    withName:BuildCache_snpEff {}
+// - `BuildCache_VEP` - Download taqbix index Cache for VEP
+    withName:BuildCache_VEP {}
 //
 //## `main.nf`
 //


### PR DESCRIPTION
## Add list of processes to base config 
Currently there are resource definitions for `cpu`, `mem` and `time` in some but not in all configuration profiles. 

I think it would be nice to have a sorted list of processes in the `base.config` file where each process defines its preferred resources. The maximal ressurces from the environment specific configuration profiles can then be used to check for limitation. 

The list should contain all processes. If I missed something feel free to add them.

Also there is no configuration for the single processes yet. It would be great if we could come up with some sort of preferred resource demands and add them together (over time?)

## PR checklist
 - [x] PR is made against `dev` branch
 - [ ] PR is a hotfix against `master` branch
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/SciLifeLab/Sarek/blob/master/.github/CONTRIBUTING.md
