### PR TITLE
Markdup java options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   [#753](https://github.com/SciLifeLab/Sarek/pull/753) - Update `binac`, `cfc` configuration
 -   [#766](https://github.com/SciLifeLab/Sarek/pull/766) - Added `ps` in `r-base` and `runallelecount` containers
+-   [#XXX](https://github.com/SciLifeLab/Sarek/pull/XXX) - Autogenerates memory requirements from MarkDuplicates when less that 8G is available. cf [nf-core/rnaseq#179](https://github.com/nf-core/rnaseq/pull/179)
 
 ### `Fixed`
 

--- a/main.nf
+++ b/main.nf
@@ -302,8 +302,9 @@ process MarkDuplicates {
   when: step == 'mapping' && !params.onlyQC
 
   script:
+  markdup_java_options = (task.memory.toGiga() > 8) ? ${params.markdup_java_options} : "\"-Xms" +  (task.memory.toGiga() / 2 )+"g "+ "-Xmx" + (task.memory.toGiga() - 1)+ "g\""
   """
-  gatk --java-options ${params.markdup_java_options} \
+  gatk --java-options ${markdup_java_options} \
   MarkDuplicates \
   --MAX_RECORDS_IN_RAM 50000 \
   --INPUT ${idSample}.bam \

--- a/main.nf
+++ b/main.nf
@@ -302,7 +302,10 @@ process MarkDuplicates {
   when: step == 'mapping' && !params.onlyQC
 
   script:
-  markdup_java_options = (task.memory.toGiga() > 8) ? ${params.markdup_java_options} : "\"-Xms" +  (task.memory.toGiga() / 2 )+"g "+ "-Xmx" + (task.memory.toGiga() - 1)+ "g\""
+  markdup_java_options = (task.memory.toGiga() > 8) ?
+    ${params.markdup_java_options} :
+    "\"-Xms" +  (task.memory.toGiga() / 2 ).trunc() +"g "+ "-Xmx" + (task.memory.toGiga() - 1)+ "g\""
+
   """
   gatk --java-options ${markdup_java_options} \
   MarkDuplicates \


### PR DESCRIPTION
- Autogenerates memory requirements from MarkDuplicates when less that 8G is available
- from https://github.com/nf-core/rnaseq/pull/179

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated