### PR TITLE
Further improvments on VEP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   [#766](https://github.com/SciLifeLab/Sarek/pull/766) - Added `ps` in `r-base` and `runallelecount` containers
 -   [#774](https://github.com/SciLifeLab/Sarek/pull/774) - Autogenerates memory requirements from MarkDuplicates when less that 8G is available. cf [nf-core/rnaseq#179](https://github.com/nf-core/rnaseq/pull/179)
 -   [#775](https://github.com/SciLifeLab/Sarek/pull/775) - Update paths for munin configuration
+-   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add GeneSplicer `1.0` to container
+-   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add possibility to use VEP GeneSplicer plugin
+-   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add `removeVCF` to remove `.ann`, `.gz` and `.vcf` from a VCF filename
 
 ### `Fixed`
 
@@ -28,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   [#757](https://github.com/SciLifeLab/Sarek/pull/757) - Typos in `binac`, `cfc` configuration
 -   [#758](https://github.com/SciLifeLab/Sarek/pull/758) - Typos in `ASCAT` documentation
 -   [#765](https://github.com/SciLifeLab/Sarek/pull/765) - Check only for references that are needed to fix [#754](https://github.com/SciLifeLab/Sarek/issues/754)
+-   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Fix name collision in `annotate.nf`
 
 ## [2.3.FIX1] - 2019-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   [#775](https://github.com/SciLifeLab/Sarek/pull/775) - Update paths for munin configuration
 -   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add GeneSplicer `1.0` to container
 -   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add possibility to use VEP GeneSplicer plugin
--   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add `removeVCF` to remove `.ann`, `.gz` and `.vcf` from a VCF filename
+-   [#777](https://github.com/SciLifeLab/Sarek/pull/777) - Add `removeVCF()` function to remove `.ann`, `.gz` and `.vcf` from a VCF filename
 
 ### `Fixed`
 

--- a/annotate.nf
+++ b/annotate.nf
@@ -103,7 +103,7 @@ vcfForVep = vcfForVep.map {
 }
 
 process RunBcftoolsStats {
-  tag {"${idPatient} - ${vcf}"}
+  tag {"${idPatient} - ${variantCaller} - ${vcf}"}
 
   publishDir "${params.outDir}/Reports/BCFToolsStats", mode: params.publishDirMode
 

--- a/annotate.nf
+++ b/annotate.nf
@@ -116,7 +116,7 @@ process RunBcftoolsStats {
   when: !params.noReports
 
   script:
-    reduced_vcf = vcf.minus(".vcf").minus(".gz")
+    reduced_vcf = vcf.minus(".vcf").minus(".gz")[0]
     QC.bcftools(vcf)
 }
 
@@ -139,7 +139,7 @@ process RunVcftools {
   when: !params.noReports
 
   script:
-    reduced_vcf = vcf.minus(".vcf").minus(".gz")
+    reduced_vcf = vcf.minus(".vcf").minus(".gz")[0]
     QC.vcftools(vcf)
 }
 
@@ -168,7 +168,7 @@ process RunSnpeff {
   when: 'snpeff' in tools || 'merge' in tools
 
   script:
-  reduced_vcf = vcf.minus(".vcf").minus(".gz")
+  reduced_vcf = vcf.minus(".vcf").minus(".gz")[0]
   cache = (params.snpEff_cache && params.annotation_cache) ? "-dataDir \${PWD}/${dataDir}" : ""
   """
   snpEff -Xmx${task.memory.toGiga()}g \
@@ -229,7 +229,7 @@ process RunVEP {
   when: 'vep' in tools || 'merge' in tools
 
   script:
-  reduced_vcf = vcf.minus(".vcf").minus(".gz")
+  reduced_vcf = vcf.minus(".vcf").minus(".gz")[0]
   finalAnnotator = annotator == "snpEff" ? 'merge' : 'VEP'
   genome = params.genome == 'smallGRCh37' ? 'GRCh37' : params.genome
   dir_cache = (params.vep_cache && params.annotation_cache) ? " \${PWD}/${dataDir}" : "/.vep"
@@ -276,7 +276,7 @@ process CompressVCF {
     set annotator, variantCaller, idPatient, file("*.vcf.gz"), file("*.vcf.gz.tbi") into (vcfCompressed, vcfCompressedoutput)
 
   script:
-  reduced_vcf = vcf.minus(".vcf").minus(".gz")
+  reduced_vcf = vcf.minus(".vcf").minus(".gz")[0]
   finalAnnotator = annotator == "merge" ? "VEP" : annotator
   """
   bgzip < ${vcf} > ${vcf}.gz

--- a/annotate.nf
+++ b/annotate.nf
@@ -233,8 +233,10 @@ process RunVEP {
   genome = params.genome == 'smallGRCh37' ? 'GRCh37' : params.genome
   dir_cache = (params.vep_cache && params.annotation_cache) ? " \${PWD}/${dataDir}" : "/.vep"
   cadd = (params.cadd_cache && params.cadd_WG_SNVs && params.cadd_InDels) ? "--plugin CADD,whole_genome_SNVs.tsv.gz,InDels.tsv.gz" : ""
-  genesplicer = params.genesplicer ? "--plugin GeneSplicer,/opt/conda/envs/sarek-2.3/bin/genesplicer,/opt/conda/envs/sarek-2.3/share/genesplicer-1.0-1/human,context=200,tmpdir=/mytmp/${reduced_vcf}" : "--offline"
+  genesplicer = params.genesplicer ? "--plugin GeneSplicer,/opt/conda/envs/sarek-2.3/bin/genesplicer,/opt/conda/envs/sarek-2.3/share/genesplicer-1.0-1/human,context=200,tmpdir=\$PWD/${reduced_vcf}" : "--offline"
   """
+  mkdir ${reduced_vcf}
+
   vep \
   -i ${vcf} \
   -o ${reduced_vcf}_VEP.ann.vcf \
@@ -252,6 +254,8 @@ process RunVEP {
   --stats_file ${reduced_vcf}_VEP.summary.html \
   --total_length \
   --vcf
+
+  rm -rf ${reduced_vcf}
   """
 }
 

--- a/annotate.nf
+++ b/annotate.nf
@@ -116,7 +116,7 @@ process RunBcftoolsStats {
   when: !params.noReports
 
   script:
-    reduced_vcf = vcf.minus(.vcf).minus(.gz)
+    reduced_vcf = vcf.minus(".vcf").minus(".gz")
     QC.bcftools(vcf)
 }
 
@@ -139,7 +139,7 @@ process RunVcftools {
   when: !params.noReports
 
   script:
-    reduced_vcf = vcf.minus(.vcf).minus(.gz)
+    reduced_vcf = vcf.minus(".vcf").minus(".gz")
     QC.vcftools(vcf)
 }
 
@@ -168,7 +168,7 @@ process RunSnpeff {
   when: 'snpeff' in tools || 'merge' in tools
 
   script:
-  reduced_vcf = vcf.minus(.vcf).minus(.gz)
+  reduced_vcf = vcf.minus(".vcf").minus(".gz")
   cache = (params.snpEff_cache && params.annotation_cache) ? "-dataDir \${PWD}/${dataDir}" : ""
   """
   snpEff -Xmx${task.memory.toGiga()}g \
@@ -229,7 +229,7 @@ process RunVEP {
   when: 'vep' in tools || 'merge' in tools
 
   script:
-  reduced_vcf = vcf.minus(.vcf).minus(.gz)
+  reduced_vcf = vcf.minus(".vcf").minus(".gz")
   finalAnnotator = annotator == "snpEff" ? 'merge' : 'VEP'
   genome = params.genome == 'smallGRCh37' ? 'GRCh37' : params.genome
   dir_cache = (params.vep_cache && params.annotation_cache) ? " \${PWD}/${dataDir}" : "/.vep"
@@ -276,7 +276,7 @@ process CompressVCF {
     set annotator, variantCaller, idPatient, file("*.vcf.gz"), file("*.vcf.gz.tbi") into (vcfCompressed, vcfCompressedoutput)
 
   script:
-  reduced_vcf = vcf.minus(.vcf).minus(.gz)
+  reduced_vcf = vcf.minus(".vcf").minus(".gz")
   finalAnnotator = annotator == "merge" ? "VEP" : annotator
   """
   bgzip < ${vcf} > ${vcf}.gz

--- a/annotate.nf
+++ b/annotate.nf
@@ -138,7 +138,7 @@ process RunVcftools {
   when: !params.noReports
 
   script:
-    reduced_vcf = vcf.minus(".ann").minus(".vcf").minus(".gz")[0]
+    reduced_vcf = vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")
     QC.vcftools(vcf)
 }
 
@@ -167,7 +167,7 @@ process RunSnpeff {
   when: 'snpeff' in tools || 'merge' in tools
 
   script:
-  reduced_vcf = vcf.minus(".ann").minus(".vcf").minus(".gz")[0]
+  reduced_vcf = vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")
   cache = (params.snpEff_cache && params.annotation_cache) ? "-dataDir \${PWD}/${dataDir}" : ""
   """
   snpEff -Xmx${task.memory.toGiga()}g \
@@ -228,7 +228,7 @@ process RunVEP {
   when: 'vep' in tools || 'merge' in tools
 
   script:
-  reduced_vcf = vcf.minus(".ann").minus(".vcf").minus(".gz")[0]
+  reduced_vcf = vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")
   finalAnnotator = annotator == "snpEff" ? 'merge' : 'VEP'
   genome = params.genome == 'smallGRCh37' ? 'GRCh37' : params.genome
   dir_cache = (params.vep_cache && params.annotation_cache) ? " \${PWD}/${dataDir}" : "/.vep"
@@ -274,7 +274,7 @@ process CompressVCF {
     set annotator, variantCaller, idPatient, file("*.vcf.gz"), file("*.vcf.gz.tbi") into (vcfCompressed, vcfCompressedoutput)
 
   script:
-  reduced_vcf = vcf.minus(".ann").minus(".vcf").minus(".gz")[0]
+  reduced_vcf = vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")
   finalAnnotator = annotator == "merge" ? "VEP" : annotator
   """
   bgzip < ${vcf} > ${vcf}.gz

--- a/containers/vepgrch37/environment.yml
+++ b/containers/vepgrch37/environment.yml
@@ -8,3 +8,4 @@ channels:
 
 dependencies:
   - ensembl-vep=95.2
+  - genesplicer=1.0

--- a/containers/vepgrch38/environment.yml
+++ b/containers/vepgrch38/environment.yml
@@ -8,3 +8,4 @@ channels:
 
 dependencies:
   - ensembl-vep=95.2
+  - genesplicer=1.0

--- a/docs/ANNOTATION.md
+++ b/docs/ANNOTATION.md
@@ -53,3 +53,13 @@ Such files are meant to be share between multiple users, so this script is mainl
 ```
 nextflow run build.nf --cadd_cache /Path/To/CADDcache --genome <GENOME>
 ```
+
+## Using VEP GeneSplicer plugin
+
+To enable the use of the VEP GeneSplicer plugin:
+ - use the `--genesplicer` flag
+
+Example:
+```
+nextflow run annotate.nf --tools VEP --annotateVCF file.vcf.gz --genome GRCh38 --genesplicer
+```

--- a/docs/CONTAINERS.md
+++ b/docs/CONTAINERS.md
@@ -35,6 +35,7 @@ Additional containers need to be downloaded for somatic variant calling with ASC
 - Contain **[FastQC][fastqc-link]** 0.11.8
 - Contain **[FreeBayes][freebayes-link]** 1.2.0
 - Contain **[GATK4][gatk4-link]** 4.0.9.0
+- Contain **[GeneSplicer][genesplicer-link]** 1.0
 - Contain **[HTSlib][htslib-link]** 1.9
 - Contain **[IGVtools][igvtools-link]** 2.3.93
 - Contain **[Manta][manta-link]** 1.4.0
@@ -62,12 +63,14 @@ Additional containers need to be downloaded for somatic variant calling with ASC
 ### vepgrch37 [![vepgrch37-docker status][vepgrch37-docker-badge]][vepgrch37-docker-link]
 
 - Based on `nfcore/base:latest`
+- Contain **[GeneSplicer][genesplicer-link]** 1.0
 - Contain **[VEP][vep-link]** 95.1
 - Contain cache for GRCh37 version 95
 
 ### vepgrch38 [![vepgrch38-docker status][vepgrch38-docker-badge]][vepgrch38-docker-link]
 
 - Based on `nfcore/base:latest`
+- Contain **[GeneSplicer][genesplicer-link]** 1.0
 - Contain **[VEP][vep-link]** 95.1
 - Contain cache for GRCh38 version 95
 
@@ -131,6 +134,7 @@ You'll just need to specify the correct repository either in command line or in 
 [fastqc-link]: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 [freebayes-link]: https://github.com/ekg/freebayes
 [gatk4-link]: https://github.com/broadinstitute/gatk
+[genesplicer-link]: https://ccb.jhu.edu/software/genesplicer/
 [htslib-link]: https://github.com/samtools/htslib
 [igvtools-link]: http://software.broadinstitute.org/software/igv/
 [manta-link]: https://github.com/Illumina/manta

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - fontconfig=2.12.6 #for FastQC
   - freebayes=1.2.0
   - gatk4=4.0.9.0
+  - genesplicer=1.0
   - htslib=1.9
   - igvtools=2.3.93
   - manta=1.4.0

--- a/germlineVC.nf
+++ b/germlineVC.nf
@@ -401,7 +401,7 @@ process RunBcftoolsStats {
     set variantCaller, file(vcf) from vcfForBCFtools
 
   output:
-    file ("${vcf.simpleName}.bcf.tools.stats.out") into bcfReport
+    file ("*.bcf.tools.stats.out") into bcfReport
 
   when: !params.noReports
 
@@ -424,7 +424,8 @@ process RunVcftools {
     set variantCaller, file(vcf) from vcfForVCFtools
 
   output:
-    file ("${vcf.simpleName}.*") into vcfReport
+    reducedVCF = SarekUtils.reduceVCF(vcf)
+    file ("${reducedVCF}.*") into vcfReport
 
   when: !params.noReports
 

--- a/germlineVC.nf
+++ b/germlineVC.nf
@@ -393,7 +393,7 @@ vcfForQC = Channel.empty().mix(
 (vcfForBCFtools, vcfForVCFtools) = vcfForQC.into(2)
 
 process RunBcftoolsStats {
-  tag {vcf}
+  tag {"${variantCaller} - ${vcf}"}
 
   publishDir "${params.outDir}/Reports/BCFToolsStats", mode: params.publishDirMode
 
@@ -416,7 +416,7 @@ if (params.verbose) bcfReport = bcfReport.view {
 bcfReport.close()
 
 process RunVcftools {
-  tag {vcf}
+  tag {"${variantCaller} - ${vcf}"}
 
   publishDir "${params.outDir}/Reports/VCFTools", mode: params.publishDirMode
 
@@ -424,12 +424,13 @@ process RunVcftools {
     set variantCaller, file(vcf) from vcfForVCFtools
 
   output:
-    reducedVCF = SarekUtils.reduceVCF(vcf)
     file ("${reducedVCF}.*") into vcfReport
 
   when: !params.noReports
 
-  script: QC.vcftools(vcf)
+  script:
+    reducedVCF = SarekUtils.reduceVCF(vcf)
+    QC.vcftools(vcf)
 }
 
 if (params.verbose) vcfReport = vcfReport.view {

--- a/lib/QC.groovy
+++ b/lib/QC.groovy
@@ -2,7 +2,7 @@ class QC {
 // Run bcftools on vcf file
   static def bcftools(vcf) {
     """
-    bcftools stats ${vcf} > ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}.bcf.tools.stats.out
+    bcftools stats ${vcf} > ${SarekUtils.reduceVCF(vcf)}.bcf.tools.stats.out
     """
   }
 
@@ -19,22 +19,22 @@ class QC {
     vcftools \
     --gzvcf ${vcf} \
     --relatedness2 \
-    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
+    --out ${SarekUtils.reduceVCF(vcf)}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-count \
-    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
+    --out ${SarekUtils.reduceVCF(vcf)}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-qual \
-    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
+    --out ${SarekUtils.reduceVCF(vcf)}
 
     vcftools \
     --gzvcf ${vcf} \
     --FILTER-summary \
-    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
+    --out ${SarekUtils.reduceVCF(vcf)}
     """
   }
 }

--- a/lib/QC.groovy
+++ b/lib/QC.groovy
@@ -2,7 +2,7 @@ class QC {
 // Run bcftools on vcf file
   static def bcftools(vcf) {
     """
-    bcftools stats ${vcf} > ${vcf.simpleName}.bcf.tools.stats.out
+    bcftools stats ${vcf} > ${vcf.minus(".vcf").minus(".gz")}.bcf.tools.stats.out
     """
   }
 
@@ -19,22 +19,22 @@ class QC {
     vcftools \
     --gzvcf ${vcf} \
     --relatedness2 \
-    --out ${vcf.simpleName}
+    --out ${vcf.minus(".vcf").minus(".gz")[0]}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-count \
-    --out ${vcf.simpleName}
+    --out ${vcf.minus(".vcf").minus(".gz")[0]}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-qual \
-    --out ${vcf.simpleName}
+    --out ${vcf.minus(".vcf").minus(".gz")[0]}
 
     vcftools \
     --gzvcf ${vcf} \
     --FILTER-summary \
-    --out ${vcf.simpleName}
+    --out ${vcf.minus(".vcf").minus(".gz")[0]}
     """
   }
 }

--- a/lib/QC.groovy
+++ b/lib/QC.groovy
@@ -2,7 +2,7 @@ class QC {
 // Run bcftools on vcf file
   static def bcftools(vcf) {
     """
-    bcftools stats ${vcf} > ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}.bcf.tools.stats.out
+    bcftools stats ${vcf} > ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}.bcf.tools.stats.out
     """
   }
 
@@ -19,22 +19,22 @@ class QC {
     vcftools \
     --gzvcf ${vcf} \
     --relatedness2 \
-    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-count \
-    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-qual \
-    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
 
     vcftools \
     --gzvcf ${vcf} \
     --FILTER-summary \
-    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")}
     """
   }
 }

--- a/lib/QC.groovy
+++ b/lib/QC.groovy
@@ -2,7 +2,7 @@ class QC {
 // Run bcftools on vcf file
   static def bcftools(vcf) {
     """
-    bcftools stats ${vcf} > ${vcf.minus(".vcf").minus(".gz")}.bcf.tools.stats.out
+    bcftools stats ${vcf} > ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}.bcf.tools.stats.out
     """
   }
 
@@ -19,22 +19,22 @@ class QC {
     vcftools \
     --gzvcf ${vcf} \
     --relatedness2 \
-    --out ${vcf.minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-count \
-    --out ${vcf.minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
 
     vcftools \
     --gzvcf ${vcf} \
     --TsTv-by-qual \
-    --out ${vcf.minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
 
     vcftools \
     --gzvcf ${vcf} \
     --FILTER-summary \
-    --out ${vcf.minus(".vcf").minus(".gz")[0]}
+    --out ${vcf.minus(".ann").minus(".vcf").minus(".gz")[0]}
     """
   }
 }

--- a/lib/SarekUtils.groovy
+++ b/lib/SarekUtils.groovy
@@ -62,6 +62,7 @@ class SarekUtils {
       'download',
       'explicit-bqsr-needed',
       'explicitBqsrNeeded',
+      'genesplicer',
       'genome_base',
       'genome-dict',
       'genome-file',

--- a/lib/SarekUtils.groovy
+++ b/lib/SarekUtils.groovy
@@ -211,6 +211,12 @@ class SarekUtils {
     return test
   }
 
+  // Remove .ann .gz and .vcf extension from a VCF file
+  static def reduceVCF(file) {
+    return file.fileName.toString().minus(".ann").minus(".vcf").minus(".gz")
+  }
+
+
   // Return file if it exists
   static def returnFile(it) {
     if (!file(it).exists()) exit 1, "Missing file in TSV file: ${it}, see --help for more information"

--- a/somaticVC.nf
+++ b/somaticVC.nf
@@ -663,7 +663,7 @@ process RunBcftoolsStats {
     set variantCaller, file(vcf) from vcfForBCFtools
 
   output:
-    file ("${vcf.simpleName}.bcf.tools.stats.out") into bcfReport
+    file ("*.bcf.tools.stats.out") into bcfReport
 
   when: !params.noReports
 
@@ -686,11 +686,13 @@ process RunVcftools {
     set variantCaller, file(vcf) from vcfForVCFtools
 
   output:
-    file ("${vcf.simpleName}.*") into vcfReport
+    file ("${reducedVCF}.*") into vcfReport
 
   when: !params.noReports
 
-  script: QC.vcftools(vcf)
+  script:
+    reducedVCF = SarekUtils.reduceVCF(vcf)
+    QC.vcftools(vcf)
 }
 
 if (params.verbose) vcfReport = vcfReport.view {

--- a/somaticVC.nf
+++ b/somaticVC.nf
@@ -677,20 +677,22 @@ if (params.verbose) bcfReport = bcfReport.view {
 
 bcfReport.close()
 
-process RunBcftoolsStats {
+process RunVcftools {
   tag {"${variantCaller} - ${vcf}"}
 
-  publishDir "${params.outDir}/Reports/BCFToolsStats", mode: params.publishDirMode
+  publishDir "${params.outDir}/Reports/VCFTools", mode: params.publishDirMode
 
   input:
-    set variantCaller, file(vcf) from vcfForBCFtools
+    set variantCaller, file(vcf) from vcfForVCFtools
 
   output:
-    file ("*.bcf.tools.stats.out") into bcfReport
+    file ("${reducedVCF}.*") into vcfReport
 
   when: !params.noReports
 
-  script: QC.bcftools(vcf)
+  script:
+    reducedVCF = SarekUtils.reduceVCF(vcf)
+    QC.vcftools(vcf)
 }
 
 if (params.verbose) vcfReport = vcfReport.view {

--- a/somaticVC.nf
+++ b/somaticVC.nf
@@ -677,22 +677,20 @@ if (params.verbose) bcfReport = bcfReport.view {
 
 bcfReport.close()
 
-process RunVcftools {
-  tag {vcf}
+process RunBcftoolsStats {
+  tag {"${variantCaller} - ${vcf}"}
 
-  publishDir "${params.outDir}/Reports/VCFTools", mode: params.publishDirMode
+  publishDir "${params.outDir}/Reports/BCFToolsStats", mode: params.publishDirMode
 
   input:
-    set variantCaller, file(vcf) from vcfForVCFtools
+    set variantCaller, file(vcf) from vcfForBCFtools
 
   output:
-    file ("${reducedVCF}.*") into vcfReport
+    file ("*.bcf.tools.stats.out") into bcfReport
 
   when: !params.noReports
 
-  script:
-    reducedVCF = SarekUtils.reduceVCF(vcf)
-    QC.vcftools(vcf)
+  script: QC.bcftools(vcf)
 }
 
 if (params.verbose) vcfReport = vcfReport.view {


### PR DESCRIPTION
- Adding the possibility to use the VEP GeneSplicer plugin
- VCFs from Manta won't over write any more
- Add new `reduceVCF()` function to remove `.ann`, .`gz` and `.vcf` from a vcf file name

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated