### PR TITLE
use -K 100000000 for bwa mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   [#744](https://github.com/SciLifeLab/Sarek/pull/744) - Refactor `germlineVC.nf`
 -   [#776](https://github.com/SciLifeLab/Sarek/pull/776) - Helper script now download annotations for VEP CADD plugin
 -   [#778](https://github.com/SciLifeLab/Sarek/pull/778) - add `|| true` for all tools when gathering versions
+-   [#787](https://github.com/SciLifeLab/Sarek/pull/787) - Use `-K 100000000` option for `bwa mem` to avoid non-deterministic results
 
 ### `Added`
 

--- a/main.nf
+++ b/main.nf
@@ -169,7 +169,7 @@ process MapReads {
   extra = status == 1 ? "-B 3" : ""
   if (SarekUtils.hasExtension(inputFile1,"fastq.gz"))
     """
-    bwa mem -R \"${readGroup}\" ${extra} -t ${task.cpus} -M \
+    bwa mem -K 100000000 -R \"${readGroup}\" ${extra} -t ${task.cpus} -M \
     ${genomeFile} ${inputFile1} ${inputFile2} | \
     samtools sort --threads ${task.cpus} -m 2G - > ${idRun}.bam
     """


### PR DESCRIPTION
- use `-K 100000000` to avoid non-deterministic results with `bwa mem`

## PR checklist
 - [X] PR is made against `dev` branch
 - [X] This comment contains a description of changes (with reason)
 - [X] If you've fixed a bug or added code that should be tested, add tests!
 - [X] Ensure the test suite passes (`./scripts/test.sh -p docker -t ALL`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated